### PR TITLE
PR: Several fixes for the conda backend and the test suite

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -3,6 +3,10 @@ name: Linux tests
 
 on: [pull_request, push]
 
+concurrency:
+  group: linux-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Test Python ${{ matrix.python-version }} Executable ${{ matrix.conda-like }}
@@ -13,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.9', '3.11']
         conda-like: ['micromamba', 'conda']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            auto-update-conda: true
            channels: conda-forge
@@ -30,7 +34,7 @@ jobs:
         if: ${{matrix.conda-like == 'micromamba'}}
         shell: bash -l {0}
         run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+          curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/1.5.10 | tar -xvj bin/micromamba
           echo "ENV_BACKEND_EXECUTABLE=${{ github.workspace }}/bin/micromamba" >> $GITHUB_ENV
       - name: Setup executable backend with conda
         if: ${{matrix.conda-like == 'conda'}}
@@ -44,9 +48,9 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest --cov-report xml --cov=envs_manager -vv -x
+          pytest --cov-report xml --cov=envs_manager --color=yes -vv -x
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -3,6 +3,10 @@ name: Macos tests
 
 on: [pull_request, push]
 
+concurrency:
+  group: macos-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Test Python ${{ matrix.python-version }} Executable ${{ matrix.conda-like }}
@@ -13,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.9', '3.11']
         conda-like: ['micromamba', 'conda']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            auto-update-conda: true
            channels: conda-forge
@@ -30,7 +34,7 @@ jobs:
         if: ${{matrix.conda-like == 'micromamba'}}
         shell: bash -l {0}
         run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/1.5.10 | tar -xvj bin/micromamba
           echo "ENV_BACKEND_EXECUTABLE=${{ github.workspace }}/bin/micromamba" >> $GITHUB_ENV
       - name: Setup executable backend with conda
         if: ${{matrix.conda-like == 'conda'}}
@@ -44,9 +48,9 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest --cov-report xml --cov=envs_manager -vv -x
+          pytest --cov-report xml --cov=envs_manager --color=yes -vv -x
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,16 +1,18 @@
 # Run the project's Pre-Commit hooks
-name: Black
+name: Pre-commit
 
 on: [pull_request, push]
 
 jobs:
   black:
-    name: Black with Pre-Commit
+    name: Validations with Pre-Commit
     runs-on: ubuntu-latest
     steps:
     - name: Checkout envs-manager repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
     - name: Run Pre-Commit hooks
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -3,6 +3,10 @@ name: Windows tests
 
 on: [pull_request, push]
 
+concurrency:
+  group: windows-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Test Python ${{ matrix.python-version }} Executable ${{ matrix.conda-like }}
@@ -13,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.9', '3.11']
         conda-like: ['micromamba', 'conda']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            auto-update-conda: true
            channels: conda-forge
@@ -31,7 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mkdir micromamba
-          curl -Ls https://micro.mamba.pm/api/micromamba/win-64/latest | tar -xvj -C micromamba
+          curl -Ls https://micro.mamba.pm/api/micromamba/win-64/1.5.10 | tar -xvj -C micromamba
           echo "ENV_BACKEND_EXECUTABLE=${{ github.workspace }}\micromamba\Library\bin\micromamba.exe" >> $GITHUB_ENV
           echo "MAMBA_ROOT_PREFIX=${{ github.workspace }}\micromamba" >> $GITHUB_ENV
       - name: Setup executable backend with conda
@@ -46,9 +50,9 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest --cov-report xml --cov=envs_manager -vv -x
+          pytest --cov-report xml --cov=envs_manager --color=yes -vv -x
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,16 @@
 exclude: ^envs_manager/tests/env_files
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.6.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.5.0
+    hooks:
+      - id: pycln
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 24.10.0
     hooks:
       - id: black

--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -112,8 +112,6 @@ class CondaLikeInterface(EnvManagerInstance):
                 self.environment_path,
                 f"--file={import_file_path}",
             ]
-            if force:
-                command += ["-y"]
         else:
             command = [
                 self.external_executable,
@@ -123,8 +121,10 @@ class CondaLikeInterface(EnvManagerInstance):
                 self.environment_path,
                 f"--file={import_file_path}",
             ]
-            if force:
-                command += ["--force"]
+
+        if force:
+            command += ["-y"]
+
         try:
             result = run_command(command, capture_output=True)
             logger.info(result.stdout)

--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -39,7 +39,11 @@ class CondaLikeInterface(EnvManagerInstance):
                 result = run_command(command, capture_output=True)
                 version = result.stdout.split()
                 if len(version) <= 1:
-                    self.executable_variant = MICROMAMBA_VARIANT
+                    # We don't support Micromamba 2.0+ because it's not very reliable
+                    if parse(version[0]) < parse("2.0.0"):
+                        self.executable_variant = MICROMAMBA_VARIANT
+                    else:
+                        return False
                 else:
                     # This is the minimal conda version we support
                     if parse(version[1]) > parse("24.1.0"):

--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import subprocess
 
+from packaging.version import parse
 import yaml
 
 from envs_manager.api import EnvManagerInstance, run_command, get_package_info
@@ -40,7 +41,11 @@ class CondaLikeInterface(EnvManagerInstance):
                 if len(version) <= 1:
                     self.executable_variant = MICROMAMBA_VARIANT
                 else:
-                    self.executable_variant = version[0]
+                    # This is the minimal conda version we support
+                    if parse(version[1]) > parse("24.1.0"):
+                        self.executable_variant = version[0]
+                    else:
+                        return False
                 return True
             except Exception as error:
                 logger.error(error.stderr)
@@ -144,8 +149,6 @@ class CondaLikeInterface(EnvManagerInstance):
         force=False,
         capture_output=False,
     ):
-        if self.executable_variant != MICROMAMBA_VARIANT:
-            packages = [f"'{package}'" for package in packages]
         command = [
             self.external_executable,
             "install",

--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -101,6 +101,7 @@ class CondaLikeInterface(EnvManagerInstance):
             logger.info(result.stdout)
             return (True, result)
         except subprocess.CalledProcessError as error:
+            logger.error(error.stderr)
             return (False, f"{error.returncode}: {error.stderr}")
 
     def import_environment(self, import_file_path, force=False):
@@ -130,6 +131,7 @@ class CondaLikeInterface(EnvManagerInstance):
             logger.info(result.stdout)
             return (True, result)
         except subprocess.CalledProcessError as error:
+            logger.error(error.stderr)
             return (
                 False,
                 f"{error.returncode}: {error.stderr}\nNote: Importing environments only works for environment definitions created with the same operating system.",
@@ -161,6 +163,7 @@ class CondaLikeInterface(EnvManagerInstance):
                 logger.info(result.stdout)
             return (True, result)
         except subprocess.CalledProcessError as error:
+            logger.error(error.stderr)
             formatted_error = f"{error.returncode}: {error.stderr}"
             return (False, formatted_error)
 
@@ -181,6 +184,7 @@ class CondaLikeInterface(EnvManagerInstance):
         except subprocess.CalledProcessError as error:
             if "PackagesNotFoundError" in error.stderr:
                 return (True, error)
+            logger.error(error.stderr)
             formatted_error = f"{error.returncode}: {error.stderr}"
             return (False, formatted_error)
 
@@ -204,6 +208,7 @@ class CondaLikeInterface(EnvManagerInstance):
             else:
                 return (True, result)
         except subprocess.CalledProcessError as error:
+            logger.error(error.stderr)
             formatted_error = f"{error.returncode}: {error.stderr}"
             return (False, formatted_error)
 
@@ -284,6 +289,6 @@ class CondaLikeInterface(EnvManagerInstance):
 
             return (environments, result)
         except subprocess.CalledProcessError as error:
+            logger.error(error.stderr)
             formatted_error = f"{error.returncode}: {error.stderr}"
-            logger.error(formatted_error)
             return (environments, formatted_error)

--- a/envs_manager/backends/venv_interface.py
+++ b/envs_manager/backends/venv_interface.py
@@ -36,7 +36,7 @@ class VEnvInterface(EnvManagerInstance):
 
     def validate(self):
         try:
-            import venv
+            import venv  # noqa
 
             return True
         except ImportError:

--- a/envs_manager/tests/env_files/conda-like-files/linux_conda_export_env.yml
+++ b/envs_manager/tests/env_files/conda-like-files/linux_conda_export_env.yml
@@ -1,4 +1,4 @@
-name: 
+name:
 channels:
 - https://conda.anaconda.org/conda-forge
 dependencies:
@@ -27,4 +27,3 @@ dependencies:
 - tzdata==2022c=h191b570_0
 - wheel==0.37.1=pyhd8ed1ab_0
 - xz==5.2.6=h166bdaf_0
-

--- a/envs_manager/tests/env_files/conda-like-files/macos_conda_export_env.yml
+++ b/envs_manager/tests/env_files/conda-like-files/macos_conda_export_env.yml
@@ -1,4 +1,4 @@
-name: 
+name:
 channels:
 - https://conda.anaconda.org/conda-forge
 dependencies:
@@ -20,4 +20,3 @@ dependencies:
 - tzdata==2022c=h191b570_0
 - wheel==0.37.1=pyhd8ed1ab_0
 - xz==5.2.6=h775f41a_0
-

--- a/envs_manager/tests/env_files/conda-like-files/win_conda_export_env.yml
+++ b/envs_manager/tests/env_files/conda-like-files/win_conda_export_env.yml
@@ -1,4 +1,4 @@
-name: 
+name:
 channels:
 - https://conda.anaconda.org/conda-forge
 dependencies:
@@ -21,4 +21,3 @@ dependencies:
 - vs2015_runtime==14.29.30139=h890b9b1_7
 - wheel==0.37.1=pyhd8ed1ab_0
 - xz==5.2.6=h8d14728_0
-

--- a/envs_manager/tests/test_cli.py
+++ b/envs_manager/tests/test_cli.py
@@ -27,7 +27,11 @@ BACKENDS = [
     ("venv", [""], "test_env", "pip"),
     (
         "conda-like",
-        ["Transaction finished", "Executing transaction: ...working... done"],
+        [
+            "Transaction finished",
+            "Executing transaction:",
+            "Downloading and Extracting Packages:",
+        ],
         "test_env",
         "python",
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ envs-manager = "envs_manager.cli:main"
 [project.optional-dependencies]
 test = [
   "pytest",
-  "pytest-cov"
+  "pytest-cov",
+  "flaky",
 ]
 pre-commit = [
   "pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
+  "packaging",
   "pyyaml",
-  "requests"
+  "requests",
 ]
 dynamic = ["version"]
 

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   # Installation dependencies
   - pyyaml
   - requests
+  - packaging
 
   # For autoformat with Black
   - pre-commit
@@ -14,3 +15,4 @@ dependencies:
   # For testing
   - pytest
   - pytest-cov
+  - flaky


### PR DESCRIPTION
- Use `-y` to accept changes when using conda to import an env.
- Log errors that result from running a command with `subprocess`.
- Remove code that it's not needed with conda 24.1.0+ and add that as our minimal supported version.
- Add `packaging` as a new dependency to be able to compare package versions, and `flaky` as a new test dependency.