### PR TITLE
PR: Fix passing multiple channels when creating envs/installing packages with the Conda-like backend

### DIFF
--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -60,7 +60,8 @@ class CondaLikeInterface(EnvManagerInstance):
         if packages:
             command += packages
         if channels:
-            command += ["-c"] + channels
+            for channel in channels:
+                command += ["-c"] + [channel]
         if force:
             command += ["-y"]
         try:
@@ -162,8 +163,8 @@ class CondaLikeInterface(EnvManagerInstance):
         if force:
             command += ["-y"]
         if channels:
-            channels = ["-c"] + channels
-            command += channels
+            for channel in channels:
+                command += ["-c"] + [channel]
         try:
             result = run_command(command, capture_output=capture_output)
             if capture_output:


### PR DESCRIPTION
Multiple channels are passed to Conda/Mamba as `conda -c defaults -c conda-forge`, but the we were doing instead `conda -c defaults conda-forge`.